### PR TITLE
feat: Implement dynamic ACORD-aware field grouping

### DIFF
--- a/src/grouper.py
+++ b/src/grouper.py
@@ -21,21 +21,69 @@ def group_fields(extracted_json_path: str, output_path: str):
 
         # This prompt is engineered for modern LLMs to group fields effectively.
         prompt = f"""
-        You are an expert insurance data architect. Your task is to group the following list of extracted form fields into logical categories.
+You are an expert insurance data architect familiar with ACORD data modeling and object-based standards.
 
-        Use the following categories:
-        - "Applicant Details"
-        - "Pet Information"
-        - "Health History"
-        - "Coverage Selection"
-        - "Payment Information"
-        - "Other"
+Task:
+Group the following extracted fields into natural, human-readable categories that represent domain objects (for example: Policy, Insured, Party, Address, Contact, Claim, Coverage, Vehicle, Treatment, Amounts). Do NOT use a fixed set of categories — create group names that best reflect the data provided.
 
-        Here is the list of fields to categorize:
-        {json.dumps(extracted_fields, indent=2)}
+Design goals and constraints:
+- Prefer ACORD-style object names when they naturally match the fields (e.g., "Policy", "Insured", "Claim", "Address"). Use examples only as guidance; you are free to create appropriate group names if the data suggests a different object (e.g., "Vehicle", "Beneficiary").
+- Each field must belong to exactly one group.
+- Groups names should be concise (1–3 words).
+- Avoid creating an "Other" group unless truly necessary.
+- Output MUST be valid JSON only. Do not write explanatory text.
 
-        Return a single JSON object where each key is a category name and the value is a list of the fields belonging to that category. Do not create new categories.
-        """
+Additional accuracy guidelines:
+1. **Preserve semantic meaning**: Do not rename field labels; return `field_name` exactly as provided.
+2. **Prioritize ACORD object hierarchy**: Where possible, align groups to ACORD’s known objects (Policy, Party, Insured, Claim, Coverage, Premium, Vehicle, Risk, Payment, Contact, Address, Amounts, Codes).
+3. **Consistency across forms**: If two fields from different forms represent the same logical concept (e.g., "DOB", "Date of Birth"), group them under the same object name (e.g., Party/Insured).
+4. **Disambiguation rule**: If a field could belong to multiple objects, choose the *most specific object* (e.g., “Vehicle VIN” → Vehicle, not Policy).
+5. **Granularity rule**: Do not collapse unrelated fields into one broad group. Keep groups focused (e.g., separate "Address" from "Contact").
+6. **Datatype accuracy**: Always infer and provide `suggested_datatype` realistically:
+   - Dates → `date`
+   - Identifiers (Policy Number, Claim Number) → `string`
+   - Money amounts → `currency`
+   - Boolean (Yes/No, true/false) → `boolean`
+   - Enumerations (State, Gender, Currency) → `code`
+   - Others default → `string`
+7. **Code list hints**: If the field clearly maps to a common ACORD code list, provide a short identifier:
+   - U.S. States → `"StateCode"`
+   - ISO currencies → `"CurrencyCode"`
+   - Gender → `"GenderCode"`
+   - Relationship → `"RelationshipCode"`
+   - Otherwise → `null`
+8. **Group ordering**: Place high-level groups (Policy, Insured, Claim, Coverage) before detail groups (Address, Contact, Payment).
+9. **Traceability**: Include `acord_object_hint` for every field. If uncertain, provide your *best guess* (e.g., "Policy/PolicyNumber").
+10. **No duplication**: Do not repeat the same field under multiple groups.
+11. **Minimal nesting**: Only use one level of groups (no group-inside-group). ACORD alignment can happen via `acord_object_hint`.
+
+For each field, return:
+- `field_name` (original text)
+- `description` (original text)
+- `acord_object_hint` (short ACORD-like object path or null)
+- `suggested_datatype` (see rules above)
+- `suggested_code_list` (short list name or null)
+
+Output schema (strictly follow this JSON shape):
+{{
+  "<GroupName>": {{
+    "Fields": [
+      {{
+        "field_name": "<original field label>",
+        "description": "<original description>",
+        "acord_object_hint": "<optional short hint or null>",
+        "suggested_datatype": "<string|integer|number|boolean|date|datetime|currency|code>",
+        "suggested_code_list": "<optional code list name or null>"
+      }},
+      ...
+    ]
+  }},
+  ...
+}}
+
+Here are the fields to categorize:
+{json.dumps(extracted_fields, indent=2)}
+"""
 
         # Call the LLM client for the grouping task
         logging.info("Calling LLM for field grouping...")

--- a/src/schema_builder.py
+++ b/src/schema_builder.py
@@ -41,20 +41,20 @@ def build_master_schema(grouped_files_dir: str, output_path: str):
             with open(grouped_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
-                # In a real implementation, this merging logic would be much more
-                # sophisticated, handling conflicts, standardizing field names,
-                # and performing deep merges.
-                # For this stub, we'll do a simple, naive merge.
-                for category, fields in data.items():
-                    # This is a placeholder for actual category mapping.
-                    if "Applicant" in category:
-                        master_schema["insured_party"].update({f["field_name"]: f for f in fields})
-                    elif "Pet" in category or "Health" in category:
-                        master_schema["policy_info"].update({f["field_name"]: f for f in fields})
-                    elif "Coverage" in category or "Payment" in category:
-                        master_schema["claim_details"].update({f["field_name"]: f for f in fields})
-                    else:
-                        master_schema["domain_specific"].update({f["field_name"]: f for f in fields})
+                # This logic is updated to handle the new ACORD-aware grouping structure.
+                # It maps common ACORD object names to the master schema's sections.
+                for category, group_object in data.items():
+                    field_list = group_object.get("Fields", [])  # Safely get the list of fields
+
+                    # Map new ACORD-style categories to the master schema sections
+                    if category in ["Policy"]:
+                        master_schema["policy_info"].update({f["field_name"]: f for f in field_list})
+                    elif category in ["Insured", "Insured Pet", "Party", "Beneficiary", "Applicant Details"]:
+                        master_schema["insured_party"].update({f["field_name"]: f for f in field_list})
+                    elif category in ["Claim", "Treatment", "Amounts", "Payment", "Coverage", "Health History"]:
+                        master_schema["claim_details"].update({f["field_name"]: f for f in field_list})
+                    else:  # Address, Vehicle, Contact, etc. go here
+                        master_schema["domain_specific"].update({f["field_name"]: f for f in field_list})
 
             master_schema["metadata"]["source_files"].append(grouped_file.name)
 


### PR DESCRIPTION
Replaced the hardcoded, static field grouping logic in `src/grouper.py` with a new dynamic prompt. The new prompt instructs the LLM to use natural, ACORD-style object names for categorization, making the grouping more flexible and standards-aligned.

Updated `src/schema_builder.py` to be compatible with the new, nested JSON structure produced by the updated grouper. The schema builder's mapping logic was also improved to recognize common ACORD-style categories (e.g., Policy, Insured, Claim) and map them to the appropriate sections in the master schema, ensuring the end-to-end pipeline remains functional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * ACORD-aware field grouping into domain objects (e.g., Policy, Insured, Claim, Coverage) for clearer organization.
  * Strict JSON output with per-field metadata (description, datatype, code list hints) to improve consistency and downstream use.

* Refactor
  * Master schema merge uses explicit ACORD mappings into policy_info, insured_party, claim_details, and domain_specific sections for predictable results.
  * Streamlined category handling to reduce misclassification and ensure safer parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->